### PR TITLE
Fix crash when reminder audio codec is unavailable (WINDOWSILL-CE)

### DIFF
--- a/src/WindowSill.ShortTermReminder/Views/FullScreenNotificationContent.xaml.cs
+++ b/src/WindowSill.ShortTermReminder/Views/FullScreenNotificationContent.xaml.cs
@@ -1,5 +1,4 @@
 using Windows.Media.Core;
-
 using WindowSill.ShortTermReminder.ViewModels;
 
 namespace WindowSill.ShortTermReminder.Views;
@@ -17,12 +16,9 @@ internal sealed partial class FullScreenNotificationContent : UserControl
         ViewModel = viewModel;
         _playAudio = playAudio;
 
-        var uri = new Uri($@"{Environment.GetFolderPath(Environment.SpecialFolder.Windows)}\media\Windows Notify Calendar.wav");
-        var audioNotificationMediaSource = MediaSource.CreateFromUri(uri);
-
         InitializeComponent();
 
-        BackgroundMediaPlayer.Source = audioNotificationMediaSource;
+        TrySetAudioSource();
     }
 
     /// <summary>
@@ -30,11 +26,35 @@ internal sealed partial class FullScreenNotificationContent : UserControl
     /// </summary>
     internal FullScreenNotificationViewModel ViewModel { get; }
 
+    private void TrySetAudioSource()
+    {
+        try
+        {
+            var uri = new Uri($@"{Environment.GetFolderPath(Environment.SpecialFolder.Windows)}\media\Windows Notify Calendar.wav");
+            BackgroundMediaPlayer.Source = MediaSource.CreateFromUri(uri);
+        }
+        catch (Exception ex)
+        {
+            // Some Windows editions (e.g. "N"/"KN" without the Media Feature Pack) don't have the
+            // media components registered, so MediaSource.CreateFromUri throws REGDB_E_CLASSNOTREG.
+            // Audio is optional for the reminder, so degrade gracefully and still show the notification
+            // without sound instead of letting the exception crash the app.
+            this.Log().LogWarning(ex, "Unable to load reminder notification audio. The reminder will be shown without sound.");
+        }
+    }
+
     private void BackgroundMediaPlayer_Loaded(object sender, RoutedEventArgs e)
     {
-        if (_playAudio)
+        if (_playAudio && BackgroundMediaPlayer.Source is not null)
         {
-            BackgroundMediaPlayer.MediaPlayer.Play();
+            try
+            {
+                BackgroundMediaPlayer.MediaPlayer.Play();
+            }
+            catch (Exception ex)
+            {
+                this.Log().LogWarning(ex, "Unable to play reminder notification audio.");
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

Sentry [WINDOWSILL-CE](https://etienne-baudoux.sentry.io/issues/7362124859) — fatal, 786 occurrences across 42 users.

```
COMException (0x80040154 REGDB_E_CLASSNOTREG): Class not registered
  at Windows.Media.Core.MediaSource.CreateFromUri(Uri uri)
  at WindowSill.ShortTermReminder.Views.FullScreenNotificationContent..ctor(...)
  at WindowSill.ShortTermReminder.Views.FullScreenNotificationWindow..ctor(...)
  at WindowSill.ShortTermReminder.Core.ReminderService.NotifyUserAsync(Reminder reminder)
```

`MediaSource.CreateFromUri` throws `REGDB_E_CLASSNOTREG` in the `FullScreenNotificationContent` constructor on Windows editions that lack the media components (Windows **N/KN** without the Media Feature Pack, or stripped codec installs).

The reminder timer fires the notification fire-and-forget via `_reminderService.NotifyUserAsync(reminder).Forget()`. The synchronous throw faults that task, which is never observed, so the unobserved exception is rethrown by the finalizer thread and crashes the app.

## Fix

Audio is optional for a reminder. Wrap the media-source creation and `MediaPlayer.Play()` in try/catch so a missing codec degrades gracefully — the reminder still shows, just without sound — and log a warning instead of crashing.

Fixes WINDOWSILL-CE
